### PR TITLE
Simplified FWHM

### DIFF
--- a/src/DIPOL-UF/DipolUfApp.cs
+++ b/src/DIPOL-UF/DipolUfApp.cs
@@ -1,7 +1,7 @@
 ﻿
 
 #define HOST_SERVER
-// #define IN_PROCESS
+#define IN_PROCESS
 
 using System;
 using System.Diagnostics;
@@ -31,6 +31,7 @@ namespace DIPOL_UF
             var host = connStr is null ? null : new DipolHost(new Uri(connStr));
             host?.Open();
 #else
+            
             var connStr = UiSettingsProvider.Settings.GetArray<string>("RemoteLocations")?.FirstOrDefault();
 
             var pInfo = new ProcessStartInfo()

--- a/src/DIPOL-UF/Helper.cs
+++ b/src/DIPOL-UF/Helper.cs
@@ -410,6 +410,15 @@ namespace DIPOL_UF
                    : key);
 
 
+
+        internal static double Interpolate(double x1, double x2, double y1, double y2, double x0)
+        {
+            if (Math.Abs(x2 - x1) < 1e-15)
+            {
+                return 0.0;
+            }
+            return y1 + (y2 - y1) / (x2 - x1) * (x0 - x1);
+        }
         
     }
 

--- a/src/DIPOL-UF/Helper.cs
+++ b/src/DIPOL-UF/Helper.cs
@@ -26,7 +26,7 @@ namespace DIPOL_UF
 {
     public static class Helper
     {
-
+        private static readonly double DEpsilon = Math.Pow(2, -53);
         public static Dispatcher UiDispatcher =>
             Application.Current?.Dispatcher
             ?? throw new InvalidOperationException("Dispatcher is unavailable.");
@@ -419,7 +419,52 @@ namespace DIPOL_UF
             }
             return y1 + (y2 - y1) / (x2 - x1) * (x0 - x1);
         }
-        
+
+        internal static double Percentile(ReadOnlySpan<double> data, double p)
+        {
+            if (data.IsEmpty || p is < 0 or > 1)
+            {
+                return double.NaN;
+            }
+
+            if (Math.Abs(p) < DEpsilon)
+            {
+                return data[0];
+            }
+
+            if (Math.Abs(1 - p) < DEpsilon)
+            {
+                return data[data.Length - 1];
+            }
+
+            
+            var buffer = ArrayPool<double>.Shared.Rent(data.Length);
+            try
+            {
+                data.CopyTo(buffer);
+                Array.Sort(buffer, 0, data.Length);
+
+                // Strictly non-negative value between `0` and `n - 1`
+                var x = (data.Length - 1) * p;
+
+                // Integral part of `x`
+                var i = (int)Math.Floor(x);
+                // Non-integral part of `x`
+                var g = x - i;
+
+                if (i == data.Length - 1)
+                {
+                    return buffer[i];
+                }
+
+                return (1 - g) * buffer[i] + g * buffer[i + 1];
+            }
+            finally
+            {
+                ArrayPool<double>.Shared.Return(buffer);
+            }
+        }
+
     }
 
     internal class CameraTupleOrderComparer : IComparer<(string Id, IDevice Camera)>

--- a/src/DIPOL-UF/Models/DipolImagePresenter.cs
+++ b/src/DIPOL-UF/Models/DipolImagePresenter.cs
@@ -40,31 +40,22 @@ namespace DIPOL_UF.Models
 
         public struct GaussianFitResults : IEquatable<GaussianFitResults>
         {
-            private static double Const { get; } = 2 * Math.Sqrt(2 * Math.Log(2));
-
-            public double Baseline { get; }
-            public double Scale { get; }
             public double Center { get; }
-            public double Sigma { get; }
-
+            public double FWHM { get; }
             public int Origin { get; set; }
-            public double FWHM => Const * Sigma;
 
-            public bool IsValid => Baseline >= 0 && Scale > 0 && Sigma > 0;
-
-            public GaussianFitResults(double baseLine, double scale, double center, double sigma) =>
-                (Baseline, Scale, Center, Sigma, Origin) = (baseLine, scale, center, sigma, 0);
+            public GaussianFitResults(double center, double fwhm) =>
+                (Center, FWHM, Origin) = (center, fwhm, 0);
 
             public override bool Equals(object? obj) =>
                 obj is GaussianFitResults other && Equals(other);
 
 
             public bool Equals(GaussianFitResults other) =>
-                (Baseline, Scale, Center, Sigma, Origin)
-             == (other.Baseline, other.Scale, other.Center, other.Sigma, other.Origin);
+                (Center, FWHM, Origin) == (other.Center, other.FWHM, other.Origin);
 
             public override int GetHashCode() =>
-                HashCode.Combine(Baseline, Scale, Center, Sigma);
+                HashCode.Combine(Center, FWHM, Origin);
 
             public static bool operator ==(GaussianFitResults left, GaussianFitResults right) =>
                 left.Equals(right);
@@ -825,7 +816,7 @@ namespace DIPOL_UF.Models
 
         private (GaussianFitResults Row, GaussianFitResults Column) ImageRightClickCommandExecute(MouseEventArgs args)
         {
-            if (!(args.Source is FrameworkElement elem))
+            if (args.Source is not FrameworkElement elem)
             {
                 return default;
             }
@@ -1065,9 +1056,9 @@ namespace DIPOL_UF.Models
 
 
             var rowStats =
-                new GaussianFitResults(1, 1, center.Row, ComputeFullWidthHalfMax(rowView, center.Column));
+                new GaussianFitResults(center.Row, ComputeFullWidthHalfMax(rowView, center.Column));
             var colStats =
-                new GaussianFitResults(1, 1, center.Column, ComputeFullWidthHalfMax(colView, center.Row));
+                new GaussianFitResults(center.Column, ComputeFullWidthHalfMax(colView, center.Row));
             return (rowStats, colStats);
         }
 

--- a/src/DIPOL-UF/Properties/AssemblyInfo.cs
+++ b/src/DIPOL-UF/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.6.0")]
+[assembly: AssemblyVersion("2.6.1")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/src/DIPOL-UF/ViewModels/DipolImagePresenterViewModel.cs
+++ b/src/DIPOL-UF/ViewModels/DipolImagePresenterViewModel.cs
@@ -300,11 +300,6 @@ namespace DIPOL_UF.ViewModels
             DipolImagePresenter.GaussianFitResults col
         )
         {
-            // Handles incorrect fits
-            if (!row.IsValid || !col.IsValid)
-            {
-                (row, col) = (default, default);
-            }
             var builder = new StringBuilder();
             //builder.AppendLine($"{Properties.Localization.FWHM_Center}\t({col.Origin + col.Center:F2}, {row.Origin + row.Center:F2})");
             builder.AppendFormat(Properties.Localization.FWHM_Center, col.Origin + col.Center, row.Origin + row.Center);


### PR DESCRIPTION
Approximate FWHM estimation instead of the accurate Gaussian fitting. Uses brightest pixel to determine the 'center', then performs 1D search along row and column to find two pixels, which values are below 0.5 * center_pix. Performs interpolation to slightly improve accuracy.